### PR TITLE
Modifications to UI for DABL Support

### DIFF
--- a/examples/hellocdm/ui/README.md
+++ b/examples/hellocdm/ui/README.md
@@ -34,13 +34,10 @@ By modifying this template application you can now create custom reports as requ
 
 Two changes are required once you've deployed your DAML application to the DABL cloud.
 
-1. In [src/config.js](src/config.js) you can specify the ledger ID of your deployed ledger, which you can obtain from the DABL settings page.
+1. You have to switch the `isLocalDev` flag to `false` and copy the tokens for each party into the `DABL config` section in [src/config.js](src/config.js), which you can obtain from the DABL Ledger Settings page for your ledger.
 
-2. You also have to switch the `isLocalDev` flag to `false` and copy the tokens for each party into the `DABL config` section in [src/config.js](src/config.js), which you can also obtain from the DABL settings page for your ledger.
-
-3. Finally, you'll need to change the `proxy` config entry in [package.json](package.json) to point to the DABL API endpoint, which is also listed on the DABL settings page for your ledger.
+2. Finally, you'll need to change the `proxy` config entry in [package.json](package.json) to point to the DABL API endpoint, which is also listed on the DABL Ledger Settings page for your ledger.
 
 You can now run `yarn start` again and your application will work against the deployed DABL ledger.
 
-Note that DABL uses obfuscated party names on the ledger, so you'll have to maintain a mapping between your defined party names and the DABL ones if you want to display parties in the UI. You can find out the mapping by looking at the `UserInfo` contracts in the DABL contracts view.
-
+Note that DABL uses obfuscated party names on the ledger, so you'll have to maintain a mapping between your defined party names and the DABL ones if you want to display parties in the UI. You can find out the mapping by looking at the `DABL.User:UserParty` contracts in the DABL Live Data view or copy the obfuscated party names to your clipboard from the DABL Ledger Settings.

--- a/examples/hellocdm/ui/package.json
+++ b/examples/hellocdm/ui/package.json
@@ -41,5 +41,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:7575"
+  "proxy": "http://localhost:7575/"
 }

--- a/examples/hellocdm/ui/src/components/Contracts/Contracts.js
+++ b/examples/hellocdm/ui/src/components/Contracts/Contracts.js
@@ -2,12 +2,15 @@ import React, { useState } from "react";
 import ReactJson from "react-json-view";
 import { Grid, Table, TableHead, TableRow, TableCell, TableBody, TextField, Button } from "@material-ui/core";
 import { useStyles } from "./styles";
+import config from "../../config";
 
 export default function Contracts({ contracts, columns, actions=[] }) {
 
   actions = actions ? actions : [];
   const isDefault = !columns;
-  columns = columns ? columns : [ [ "Module", "templateId.moduleName" ], [ "Template", "templateId.entityName" ], [ "ContractId", "contractId" ] ];
+  columns = columns ? columns : (config.isLocalDev
+    ? [ [ "Module", "templateId.moduleName" ], [ "Template", "templateId.entityName" ], [ "ContractId", "contractId" ] ]
+    : [[ "Template", "templateId" ], [ "ContractId", "contractId" ] ]);
 
   const classes = useStyles();
   var [state, setState] = useState({});
@@ -19,12 +22,12 @@ export default function Contracts({ contracts, columns, actions=[] }) {
     const value = getByPath(data[path[0]], path.slice(1));
     return value;
   }
-  
+
   function getValue(data, path) {
     const split = typeof path === "string" && path !== "" ? path.split(".") : [];
     return getByPath(data, split);
   }
-  
+
   return (
     <>
       <Grid container spacing={4}>

--- a/examples/hellocdm/ui/src/config.js
+++ b/examples/hellocdm/ui/src/config.js
@@ -3,13 +3,14 @@ import * as jwt from "jsonwebtoken";
 
 const isLocalDev = true;
 const continuousUpdate = false;
-const ledgerId = "hellocdm"
+const localLedgerId = "hellocdm"
 const applicationId = uuidv4();
-const createToken = party => jwt.sign({ ledgerId, applicationId, party }, "secret")
+const createToken = party => jwt.sign({ localLedgerId, applicationId, party }, "secret")
 const parties = [ "Alice" ];
 
 // Dev config
 const localConfig = {
+  isLocalDev,
   continuousUpdate,
   tokens: {}
 }
@@ -17,9 +18,10 @@ parties.map(p => localConfig.tokens[p] = createToken(p));
 
 // DABL config
 const dablConfig = {
+  isLocalDev,
   continuousUpdate,
   tokens: {
-    Alice: "" // Copy token for Alice from DABL website
+    Alice: "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRhYmwtMjAxOS0xMC0wNC0yMDUyMDYiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOlsicHJvamVjdGRhYmwiXSwiZGFibExlZGdlclBhcnR5IjoiYml3aGI5M2oxd3BjN2M1dCIsImRhYmxMZWRnZXJSaWdodHMiOlsicmVhZCIsIndyaXRlOmNyZWF0ZSIsIndyaXRlOmV4ZXJjaXNlIl0sImVtYWlsIjoiZGltaXRyaS5saWFrYWtvc0BkaWdpdGFsYXNzZXQuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImV4cCI6MTU3MDU1NzI0MywiaWF0IjoxNTcwNDcwODQzLCJpc3MiOiJwcm9qZWN0ZGFibC1zaXRlIiwianRpIjoiSFpfMkZuUkFOV1pGMzQzQnkxSTZiZyIsIm5hbWUiOiJEaW1pdHJpIExpYWtha29zIiwibmJmIjoxNTcwNDcwODQzLCJuaWNrbmFtZSI6ImRpbWl0cmkubGlha2Frb3MiLCJwaWN0dXJlIjoiaHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EtL0FBdUU3bUN2b08xYlRRWlNJZlR1V3d2SE91SU5xdkoyYVc1cFhURDlkM0I1Iiwic3ViIjoiZ29vZ2xlLWFwcHN8ZGltaXRyaS5saWFrYWtvc0BkaWdpdGFsYXNzZXQuY29tIiwidG9zQWNjZXB0ZWQiOnRydWV9.NwobjWM5a8IoVsADAfopUxA-AMCJpoQKFKtXN4LzUlIwHdsUTF5XIJEm9sq_TZ_XOJv-LDkjVinxs0Vt3WpT-3RDTVJTx6pRo6cu2hddkj3wmufK5p3iLmYaaICpJ-cjl4eDx4IbtANoeVzYj5pzU3n01ZOnULZ7PeQRZ8KUiMqbe99jxfGDRIqCX7O-zCO6q9Cj31aIL1wpbRLLuhEG1kCGQrRoLr2yETc_d7TusNumVjhRhIzmH7HaZge3-08LEqdznBPYgcjbj9WXer2VxXps4Wx9hhBgdv7mvOOeFUUI8poRGjjlDZ7wCPBIP_0Ca1FX-wDX6M4CY9YnTCzbKg" // Copy token for Alice from DABL website
   }
 }
 

--- a/examples/hellocdm/ui/src/context/LedgerContext.js
+++ b/examples/hellocdm/ui/src/context/LedgerContext.js
@@ -1,4 +1,5 @@
 import React from "react";
+import config from "../config";
 
 var LedgerStateContext = React.createContext();
 var LedgerDispatchContext = React.createContext();
@@ -118,10 +119,35 @@ export async function fetchContracts(dispatch, token, setIsFetching, setError) {
   }
 }
 
+function templateFilterSDK(contract, moduleName, entityName) {
+  if (moduleName && entityName) {
+    return (contract.templateId.moduleName === moduleName
+      && contract.templateId.entityName === entityName);
+  } else if (moduleName) {
+    return contract.templateId.moduleName === moduleName;
+  } else if (entityName) {
+    return contract.templateId.entityName === entityName;
+  }
+  return true;
+}
+
+function templateFilterDABL(contract, moduleName, entityName) {
+  if (moduleName && entityName) {
+    return contract.templateId.startsWith(moduleName + ':' + entityName + '@');
+  } else if (moduleName) {
+    return contract.templateId.startsWith(moduleName + ':');
+  } else if (entityName) {
+    return contract.templateId.includes(':' + entityName + '@');
+  }
+  return true;
+}
+
 export function getContracts(state, moduleName, entityName) {
-  return state.contracts.filter(c => c.templateId.moduleName === moduleName && c.templateId.entityName === entityName);
+  const templateFilter = config.isLocalDev ? templateFilterSDK : templateFilterDABL
+  return state.contracts.filter(c => templateFilter(c, moduleName, entityName));
 }
 
 export function getContract(state, moduleName, entityName) {
-  return state.contracts.find(c => c.templateId.moduleName === moduleName && c.templateId.entityName === entityName);
+  const templateFilter = config.isLocalDev ? templateFilterSDK : templateFilterDABL
+  return state.contracts.find(c => templateFilter(c, moduleName, entityName));
 }

--- a/examples/hellocdm/ui/src/pages/default/Default.js
+++ b/examples/hellocdm/ui/src/pages/default/Default.js
@@ -5,11 +5,11 @@ import { useLedgerState, getContracts } from "../../context/LedgerContext";
 function Default() {
 
   const ledger = useLedgerState();
-  const transfers = getContracts(ledger, "Main", "Transfer");
+  const allContracts = getContracts(ledger);
 
   return (
     <>
-      <Contracts contracts={transfers} />
+      <Contracts contracts={allContracts} />
     </>
   );
 }


### PR DESCRIPTION
This PR makes the UI code compatible with DABL.
The main difference here between local dev and DABL is the shape of the `templateId` when getting contracts `GET /contracts/search`. In local dev this is an object with `packageName`, `moduleName` and `entityName` whereas in DABL it is the string `moduleName:entityName@packageName`